### PR TITLE
feat: add tipoProducto and marca fields to Producto entity and update related layers

### DIFF
--- a/src/main/java/com/daniel/farmacia/application/dto/producto/ProductoRequestDto.java
+++ b/src/main/java/com/daniel/farmacia/application/dto/producto/ProductoRequestDto.java
@@ -1,5 +1,6 @@
 package com.daniel.farmacia.application.dto.producto;
 
+import com.daniel.farmacia.domain.entity.type.TipoProducto;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.Min;
@@ -26,6 +27,10 @@ public class ProductoRequestDto {
 
     @NotBlank(message = "El lote es obligatorio")
     private String lote;
+
+    private TipoProducto tipoProducto;
+
+    private String marca;
 
     private Long categoriaId;
 }

--- a/src/main/java/com/daniel/farmacia/application/dto/producto/ProductoResponseDto.java
+++ b/src/main/java/com/daniel/farmacia/application/dto/producto/ProductoResponseDto.java
@@ -1,5 +1,6 @@
 package com.daniel.farmacia.application.dto.producto;
 
+import com.daniel.farmacia.domain.entity.type.TipoProducto;
 import lombok.Builder;
 import lombok.Data;
 
@@ -15,6 +16,8 @@ public class ProductoResponseDto {
     private Integer stock;
     private LocalDate fechaVencimiento;
     private String lote;
+    private TipoProducto tipoProducto;
+    private String marca;
     private Long categoriaId;
     private String nombreCategoria;
 }

--- a/src/main/java/com/daniel/farmacia/application/mapper/producto/ProductoMapper.java
+++ b/src/main/java/com/daniel/farmacia/application/mapper/producto/ProductoMapper.java
@@ -4,6 +4,7 @@ import com.daniel.farmacia.application.dto.producto.ProductoRequestDto;
 import com.daniel.farmacia.application.dto.producto.ProductoResponseDto;
 import com.daniel.farmacia.domain.entity.Categoria;
 import com.daniel.farmacia.domain.entity.Producto;
+import com.daniel.farmacia.domain.entity.type.TipoProducto;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -18,12 +19,23 @@ public class ProductoMapper {
                 .stock(producto.getStock())
                 .fechaVencimiento(producto.getFechaVencimiento())
                 .lote(producto.getLote())
+                .tipoProducto(producto.getTipoProducto())
+                .marca(producto.getMarca())
                 .categoriaId(producto.getCategoria().getId())
                 .nombreCategoria(producto.getCategoria().getNombreCategoria())
                 .build();
     }
 
     public Producto toEntity(ProductoRequestDto requestDto, Categoria categoria) {
+        TipoProducto tipoProducto = requestDto.getTipoProducto() != null
+                ? requestDto.getTipoProducto()
+                : TipoProducto.MARCA;
+
+        String marca = requestDto.getMarca();
+        if (tipoProducto == TipoProducto.GENERICO && marca == null) {
+            marca = "Sin marca";
+        }
+
         return Producto.builder()
                 .nombre(requestDto.getNombreProducto())
                 .descripcion(requestDto.getDescripcionProducto())
@@ -31,6 +43,8 @@ public class ProductoMapper {
                 .stock(requestDto.getStock())
                 .fechaVencimiento(requestDto.getFechaVencimiento())
                 .lote(requestDto.getLote())
+                .tipoProducto(tipoProducto)
+                .marca(marca)
                 .categoria(categoria)
                 .build();
     }

--- a/src/main/java/com/daniel/farmacia/application/service/impl/ProductoServiceImpl.java
+++ b/src/main/java/com/daniel/farmacia/application/service/impl/ProductoServiceImpl.java
@@ -54,25 +54,26 @@ public class ProductoServiceImpl implements IProductoService {
     public ProductoResponseDto crearProducto(ProductoRequestDto requestDto) {
         CategoriaResponseDto categoriaResponseDto = categoriaService.buscarCategoriaPorId(requestDto.getCategoriaId());
         Categoria categoria = categoriaMapper.toEntityCategoria(categoriaResponseDto);
+
         Producto producto = productoMapper.toEntity(requestDto, categoria);
-        return productoMapper.toDto(productoRepository.save(producto));
+        producto = productoRepository.save(producto);
+        return productoMapper.toDto(producto);
     }
 
     @Override
     public ProductoResponseDto actualizarProducto(Long id, ProductoRequestDto requestDto) {
         Producto producto = productoRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Producto no encontrado" + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Producto no encontrado con ID: " + id));
         CategoriaResponseDto categoriaResponseDto = categoriaService.buscarCategoriaPorId(requestDto.getCategoriaId());
         Categoria categoria = categoriaMapper.toEntityCategoria(categoriaResponseDto);
 
-        producto.setNombre(requestDto.getNombreProducto());
-        producto.setDescripcion(requestDto.getDescripcionProducto());
-        producto.setPrecio(requestDto.getPrecioProducto());
-        producto.setStock(requestDto.getStock());
-        producto.setFechaVencimiento(requestDto.getFechaVencimiento());
-        producto.setLote(requestDto.getLote());
-        producto.setCategoria(categoria);
-        return productoMapper.toDto(productoRepository.save(producto));
+        // Reutilizar el mapper para la actualizacion
+        Producto productoActualizado = productoMapper.toEntity(requestDto, categoria);
+        // mantener el ID existente
+        productoActualizado.setId(producto.getId());
+        productoRepository.save(productoActualizado);
+        return productoMapper.toDto(productoActualizado);
+
     }
 
     @Override

--- a/src/main/java/com/daniel/farmacia/domain/entity/Producto.java
+++ b/src/main/java/com/daniel/farmacia/domain/entity/Producto.java
@@ -1,5 +1,6 @@
 package com.daniel.farmacia.domain.entity;
 
+import com.daniel.farmacia.domain.entity.type.TipoProducto;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Future;
@@ -47,6 +48,12 @@ public class Producto {
     @Column(nullable = false)
     @NotBlank(message = "El lote es obligatorio")
     private String lote;
+
+    @Column(name = "tipo_producto")
+    @Enumerated(EnumType.STRING)
+    private TipoProducto tipoProducto;
+
+    private String marca;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "categoria_id", nullable = false)

--- a/src/main/java/com/daniel/farmacia/domain/entity/type/TipoProducto.java
+++ b/src/main/java/com/daniel/farmacia/domain/entity/type/TipoProducto.java
@@ -1,0 +1,6 @@
+package com.daniel.farmacia.domain.entity.type;
+
+public enum TipoProducto {
+    GENERICO,
+    MARCA
+}


### PR DESCRIPTION
- Added 'tipoProducto' (enum: GENERICO/MARCA) and 'marca' (String) to Producto entity
- Updated ProductoRequestDto and ProductoResponseDto to include new fields
- Enhanced ProductoMapper to handle default values:
    - Default tipoProducto = MARCA if not provided
    - Default marca = "Sin marca" for GENERICO products if not provided
- Updated ProductoServiceImpl to use mapper consistently for create/update